### PR TITLE
fix(webapp): required inputs

### DIFF
--- a/app/(Components)/(Form)/Inputs/Input.tsx
+++ b/app/(Components)/(Form)/Inputs/Input.tsx
@@ -49,7 +49,7 @@ export const Input = ({
 						)}
 					</div>
 					<input
-						required
+						required={required}
 						className={styles.input}
 						type={type}
 						name={label}

--- a/src/BestOfTechnozaure/Event/Contact.tsx
+++ b/src/BestOfTechnozaure/Event/Contact.tsx
@@ -35,16 +35,18 @@ export const Contact: React.FC<{
 					}}
 				/>
 			</Sequence>
-			<Sequence name="Divider" from={10}>
-				<FadeIn durationInFrames={30}>
-					<Divider
-						style={{
-							top: 870,
-						}}
-						width="40%"
-					/>
-				</FadeIn>
-			</Sequence>
+			{(contact.mail || contact.phone) && (
+				<Sequence name="Divider" from={10}>
+					<FadeIn durationInFrames={30}>
+						<Divider
+							style={{
+								top: 870,
+							}}
+							width="40%"
+						/>
+					</FadeIn>
+				</Sequence>
+			)}
 			<Sequence name="Contact informations" from={10}>
 				<SlideTop from={830} to={930} durationInFrames={30}>
 					<FadeIn durationInFrames={30}>


### PR DESCRIPTION
## 🤔 Why?

The input not required, was required to generate the form.

## 💻 How?

I've set the input to required depending on the props, it was set to true every-time. I've also remove the divider if there was nothing underneath.

## ✅ How to validate this PR?

- run `pnpm dev` and try generating the event video without an email or a phone. It should work well
